### PR TITLE
Can Add Custom Menu Items to Node Menu

### DIFF
--- a/Assets/Examples/BasicExample.asset
+++ b/Assets/Examples/BasicExample.asset
@@ -39,6 +39,9 @@ MonoBehaviour:
   - rid: 22
   - rid: 23
   - rid: 3708072270747926535
+  - rid: 3708072304043098128
+  - rid: 3708072304043098133
+  - rid: 3708072304043098134
   edges:
   - GUID: 04cee6c7-b233-40e1-b41a-31f6093f1482
     owner: {fileID: 11400000}
@@ -210,6 +213,7 @@ MonoBehaviour:
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters:
   - rid: 25
+  - rid: 3708072304043098124
   serializedParameterList:
   - guid: 
     name: 
@@ -319,8 +323,8 @@ MonoBehaviour:
     title: New Sticky Note
     content: Write your text here
   nodeInspectorReference: {fileID: 0}
-  position: {x: 854, y: -5, z: 0}
-  scale: {x: 0.65751624, y: 0.65751624, z: 1}
+  position: {x: 1234, y: -179, z: 0}
+  scale: {x: 1.3225, y: 1.3225, z: 1}
   references:
     version: 2
     RefIds:
@@ -800,9 +804,9 @@ MonoBehaviour:
         computeOrder: 24
         position:
           serializedVersion: 2
-          x: -507.4715
-          y: 334.4306
-          width: 180
+          x: -516.50006
+          y: 126.999985
+          width: 223
           height: 156
         expanded: 0
         debug: 0
@@ -813,3 +817,77 @@ MonoBehaviour:
         dataOutput:
           name: esfesfesf
           value: 0
+    - rid: 3708072304043098124
+      type: {class: MyFloatParam, ns: , asm: Assembly-CSharp}
+      data:
+        guid: 95a64ec0-9ebe-450d-b8f7-501b035f33d6
+        name: New My Float Param
+        type: 
+        serializedValue:
+          serializedType: 
+          serializedName: 
+          serializedValue: 
+        input: 1
+        settings:
+          rid: 3708072304043098125
+        val: 0
+    - rid: 3708072304043098125
+      type: {class: FloatParameter/FloatSettings, ns: GraphProcessor, asm: com.alelievr.NodeGraphProcessor.Runtime}
+      data:
+        isHidden: 0
+        expanded: 0
+        guid: 95a64ec0-9ebe-450d-b8f7-501b035f33d6
+        mode: 0
+        min: 0
+        max: 1
+    - rid: 3708072304043098128
+      type: {class: CustomParameterNode, ns: , asm: Assembly-CSharp}
+      data:
+        nodeCustomName: 
+        GUID: d327ef65-ed6e-46f1-bce4-16a6b7d4f61f
+        computeOrder: 25
+        position:
+          serializedVersion: 2
+          x: -671.99994
+          y: 354.00003
+          width: 146
+          height: 36
+        expanded: 0
+        debug: 0
+        nodeLock: 0
+        parameterGUID: 95a64ec0-9ebe-450d-b8f7-501b035f33d6
+        accessor: 1
+    - rid: 3708072304043098133
+      type: {class: CustomParameterNode, ns: , asm: Assembly-CSharp}
+      data:
+        nodeCustomName: 
+        GUID: c1b521a8-e1a6-4eb1-a376-b6b22f5699ed
+        computeOrder: 26
+        position:
+          serializedVersion: 2
+          x: -648.01514
+          y: 307.7505
+          width: 100
+          height: 100
+        expanded: 0
+        debug: 0
+        nodeLock: 0
+        parameterGUID: 95a64ec0-9ebe-450d-b8f7-501b035f33d6
+        accessor: 0
+    - rid: 3708072304043098134
+      type: {class: ParameterNode, ns: GraphProcessor, asm: com.alelievr.NodeGraphProcessor.Runtime}
+      data:
+        nodeCustomName: 
+        GUID: 9c96984e-f0ca-46dc-95cc-de99b8360f93
+        computeOrder: 27
+        position:
+          serializedVersion: 2
+          x: -629.95465
+          y: 412
+          width: 91
+          height: 37
+        expanded: 0
+        debug: 0
+        nodeLock: 0
+        parameterGUID: eb80df62-f248-4ec9-afd4-f9ed08bfaa16
+        accessor: 0

--- a/Assets/Examples/DefaultNodes/Nodes/CustomMenuEntry.meta
+++ b/Assets/Examples/DefaultNodes/Nodes/CustomMenuEntry.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf6eeb67a9b8544c7a649b6d735d1362
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Examples/DefaultNodes/Nodes/CustomMenuEntry/CustomMenuEntry.cs
+++ b/Assets/Examples/DefaultNodes/Nodes/CustomMenuEntry/CustomMenuEntry.cs
@@ -1,0 +1,14 @@
+using System;
+using GraphProcessor;
+using UnityEngine;
+public static class CustomMenuEntry
+{
+    [CustomMenuItem("Custom/PresetFloatNode")]
+    public static FloatNode DoCustomNodeCreation(Type type, Vector2 mouseLocation)
+    {
+        FloatNode node = BaseNode.CreateFromType<FloatNode>(mouseLocation);
+        node.SetCustomName("Custom Creation");
+        node.input = 1337;
+        return node;
+    }
+}

--- a/Assets/Examples/DefaultNodes/Nodes/CustomMenuEntry/CustomMenuEntry.cs.meta
+++ b/Assets/Examples/DefaultNodes/Nodes/CustomMenuEntry/CustomMenuEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5dc2cf6336966602a90ae0a46b094e84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Utils/NodeProvider.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Utils/NodeProvider.cs
@@ -9,252 +9,256 @@ using UnityEditor.Experimental.GraphView;
 
 namespace GraphProcessor
 {
-	public static class NodeProvider
-	{
-		public struct PortDescription
-		{
-			public Type nodeType;
-			public Type portType;
-			public bool isInput;
-			public string portFieldName;
-			public string portIdentifier;
-			public string portDisplayName;
-		}
+    public static class NodeProvider
+    {
+        public struct PortDescription
+        {
+            public Type nodeType;
+            public Type portType;
+            public bool isInput;
+            public string portFieldName;
+            public string portIdentifier;
+            public string portDisplayName;
+        }
 
-		static Dictionary< Type, MonoScript >	nodeViewScripts = new Dictionary< Type, MonoScript >();
-		static Dictionary< Type, MonoScript >	nodeScripts = new Dictionary< Type, MonoScript >();
-		static Dictionary< Type, Type >			nodeViewPerType = new Dictionary< Type, Type >();
+        static Dictionary<Type, MonoScript> nodeViewScripts = new Dictionary<Type, MonoScript>();
+        static Dictionary<Type, MonoScript> nodeScripts = new Dictionary<Type, MonoScript>();
+        static Dictionary<Type, Type> nodeViewPerType = new Dictionary<Type, Type>();
 
-		public class NodeDescriptions
-		{
-			public Dictionary< string, Type >		nodePerMenuTitle = new Dictionary< string, Type >();
-			public List< Type >						slotTypes = new List< Type >();
-			public List< PortDescription >			nodeCreatePortDescription = new List<PortDescription>();
-		}
+        public class NodeDescriptions
+        {
+            public Dictionary<string, Type> nodePerMenuTitle = new Dictionary<string, Type>();
+            public List<Type> slotTypes = new List<Type>();
+            public List<PortDescription> nodeCreatePortDescription = new List<PortDescription>();
+        }
 
-		public struct NodeSpecificToGraph
-		{
-			public Type				nodeType;
-			public List<MethodInfo>	isCompatibleWithGraph;
-			public Type				compatibleWithGraphType;
-		} 
+        public struct NodeSpecificToGraph
+        {
+            public Type nodeType;
+            public List<MethodInfo> isCompatibleWithGraph;
+            public Type compatibleWithGraphType;
+        }
 
-		static Dictionary<BaseGraph, NodeDescriptions>	specificNodeDescriptions = new Dictionary<BaseGraph, NodeDescriptions>();
-		static List<NodeSpecificToGraph>				specificNodes = new List<NodeSpecificToGraph>();
+        static Dictionary<BaseGraph, NodeDescriptions> specificNodeDescriptions = new Dictionary<BaseGraph, NodeDescriptions>();
+        static List<NodeSpecificToGraph> specificNodes = new List<NodeSpecificToGraph>();
 
-		static NodeDescriptions							genericNodes = new NodeDescriptions();
+        static NodeDescriptions genericNodes = new NodeDescriptions();
 
-		static NodeProvider()
-		{
-			BuildScriptCache();
-			BuildGenericNodeCache();
-		}
+        static NodeProvider()
+        {
+            BuildScriptCache();
+            BuildGenericNodeCache();
+        }
 
-		public static void LoadGraph(BaseGraph graph)
-		{
-			// Clear old graph data in case there was some
-			specificNodeDescriptions.Remove(graph);
-			var descriptions = new NodeDescriptions();
-			specificNodeDescriptions.Add(graph, descriptions);
+        public static void LoadGraph(BaseGraph graph)
+        {
+            // Clear old graph data in case there was some
+            specificNodeDescriptions.Remove(graph);
+            var descriptions = new NodeDescriptions();
+            specificNodeDescriptions.Add(graph, descriptions);
 
-			var graphType = graph.GetType();
-			foreach (var nodeInfo in specificNodes)
-			{
-				bool compatible = nodeInfo.compatibleWithGraphType == null || nodeInfo.compatibleWithGraphType == graphType;
+            var graphType = graph.GetType();
+            foreach (var nodeInfo in specificNodes)
+            {
+                bool compatible = nodeInfo.compatibleWithGraphType == null || nodeInfo.compatibleWithGraphType == graphType;
 
-				if (nodeInfo.isCompatibleWithGraph != null)
-				{
-					foreach (var method in nodeInfo.isCompatibleWithGraph)
-						compatible &= (bool)method?.Invoke(null, new object[]{ graph });
-				}
+                if (nodeInfo.isCompatibleWithGraph != null)
+                {
+                    foreach (var method in nodeInfo.isCompatibleWithGraph)
+                        compatible &= (bool)method?.Invoke(null, new object[] { graph });
+                }
 
-				if (compatible)
-					BuildCacheForNode(nodeInfo.nodeType, descriptions, graph);
-			}
-		}
+                if (compatible)
+                    BuildCacheForNode(nodeInfo.nodeType, descriptions, graph);
+            }
+        }
 
-		public static void UnloadGraph(BaseGraph graph)
-		{
-			specificNodeDescriptions.Remove(graph);
-		}
+        public static void UnloadGraph(BaseGraph graph)
+        {
+            specificNodeDescriptions.Remove(graph);
+        }
 
-		static void BuildGenericNodeCache()
-		{
-			foreach (var nodeType in TypeCache.GetTypesDerivedFrom<BaseNode>())
-			{
-				if (!IsNodeAccessibleFromMenu(nodeType))
-					continue;
+        static void BuildGenericNodeCache()
+        {
+            foreach (var nodeType in TypeCache.GetTypesDerivedFrom<BaseNode>())
+            {
+                if (!IsNodeAccessibleFromMenu(nodeType))
+                    continue;
 
-				if (IsNodeSpecificToGraph(nodeType))
-					continue;
+                if (IsNodeSpecificToGraph(nodeType))
+                    continue;
 
-				BuildCacheForNode(nodeType, genericNodes);
-			}
-		}
+                BuildCacheForNode(nodeType, genericNodes);
+            }
+        }
 
-		static void BuildCacheForNode(Type nodeType, NodeDescriptions targetDescription, BaseGraph graph = null)
-		{
-			var attrs = nodeType.GetCustomAttributes(typeof(NodeMenuItemAttribute), false) as NodeMenuItemAttribute[];
+        static void BuildCacheForNode(Type nodeType, NodeDescriptions targetDescription, BaseGraph graph = null)
+        {
+            var attrs = nodeType.GetCustomAttributes(typeof(NodeMenuItemAttribute), false) as NodeMenuItemAttribute[];
 
-			if (attrs != null && attrs.Length > 0)
-			{
-				foreach (var attr in attrs)
-					targetDescription.nodePerMenuTitle[attr.menuTitle] = nodeType;
-			}
+            if (attrs != null && attrs.Length > 0)
+            {
+                foreach (var attr in attrs)
+                    targetDescription.nodePerMenuTitle[attr.menuTitle] = nodeType;
+            }
 
-			foreach (var field in nodeType.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
-			{
-				if (field.GetCustomAttribute<HideInInspector>() == null && field.GetCustomAttributes().Any(c => c is InputAttribute || c is OutputAttribute))
-					targetDescription.slotTypes.Add(field.FieldType);
-			}
+            foreach (var field in nodeType.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (field.GetCustomAttribute<HideInInspector>() == null && field.GetCustomAttributes().Any(c => c is InputAttribute || c is OutputAttribute))
+                    targetDescription.slotTypes.Add(field.FieldType);
+            }
 
-			ProvideNodePortCreationDescription(nodeType, targetDescription, graph);
-		}
+            ProvideNodePortCreationDescription(nodeType, targetDescription, graph);
+        }
 
-		static bool IsNodeAccessibleFromMenu(Type nodeType)
-		{
-			if (nodeType.IsAbstract)
-				return false;
+        static bool IsNodeAccessibleFromMenu(Type nodeType)
+        {
+            if (nodeType.IsAbstract)
+                return false;
 
-			return nodeType.GetCustomAttributes<NodeMenuItemAttribute>().Count() > 0;
-		}
+            return nodeType.GetCustomAttributes<NodeMenuItemAttribute>().Count() > 0;
+        }
 
-		// Check if node has anything that depends on the graph type or settings
-		static bool IsNodeSpecificToGraph(Type nodeType)
-		{
-			var isCompatibleWithGraphMethods = nodeType.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy).Where(m => m.GetCustomAttribute<IsCompatibleWithGraph>() != null);
-			var nodeMenuAttributes = nodeType.GetCustomAttributes<NodeMenuItemAttribute>();
+        // Check if node has anything that depends on the graph type or settings
+        static bool IsNodeSpecificToGraph(Type nodeType)
+        {
+            var isCompatibleWithGraphMethods = nodeType.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy).Where(m => m.GetCustomAttribute<IsCompatibleWithGraph>() != null);
+            var nodeMenuAttributes = nodeType.GetCustomAttributes<NodeMenuItemAttribute>();
 
-			List<Type> compatibleGraphTypes = nodeMenuAttributes.Where(n => n.onlyCompatibleWithGraph != null).Select(a => a.onlyCompatibleWithGraph).ToList();
+            List<Type> compatibleGraphTypes = nodeMenuAttributes.Where(n => n.onlyCompatibleWithGraph != null).Select(a => a.onlyCompatibleWithGraph).ToList();
 
-			List<MethodInfo> compatibleMethods = new List<MethodInfo>();
-			foreach (var method in isCompatibleWithGraphMethods)
-			{
-				// Check if the method is static and have the correct prototype
-				var p = method.GetParameters();
-				if (method.ReturnType != typeof(bool) || p.Count() != 1 || p[0].ParameterType != typeof(BaseGraph))
-					Debug.LogError($"The function '{method.Name}' marked with the IsCompatibleWithGraph attribute either doesn't return a boolean or doesn't take one parameter of BaseGraph type.");
-				else
-					compatibleMethods.Add(method);
-			}
+            List<MethodInfo> compatibleMethods = new List<MethodInfo>();
+            foreach (var method in isCompatibleWithGraphMethods)
+            {
+                // Check if the method is static and have the correct prototype
+                var p = method.GetParameters();
+                if (method.ReturnType != typeof(bool) || p.Count() != 1 || p[0].ParameterType != typeof(BaseGraph))
+                    Debug.LogError($"The function '{method.Name}' marked with the IsCompatibleWithGraph attribute either doesn't return a boolean or doesn't take one parameter of BaseGraph type.");
+                else
+                    compatibleMethods.Add(method);
+            }
 
-			if (compatibleMethods.Count > 0 || compatibleGraphTypes.Count > 0)
-			{
-				// We still need to add the element in specificNode even without specific graph
-				if (compatibleGraphTypes.Count == 0)
-					compatibleGraphTypes.Add(null);
+            if (compatibleMethods.Count > 0 || compatibleGraphTypes.Count > 0)
+            {
+                // We still need to add the element in specificNode even without specific graph
+                if (compatibleGraphTypes.Count == 0)
+                    compatibleGraphTypes.Add(null);
 
-				foreach (var graphType in compatibleGraphTypes)
-				{
-					specificNodes.Add(new NodeSpecificToGraph{
-						nodeType = nodeType,
-						isCompatibleWithGraph = compatibleMethods,
-						compatibleWithGraphType = graphType
-					});
-				}
-				return true;
-			}
-			return false;
-		}
-	
-		static void BuildScriptCache()
-		{
-			foreach (var nodeType in TypeCache.GetTypesDerivedFrom<BaseNode>())
-			{
-				if (!IsNodeAccessibleFromMenu(nodeType))
-					continue;
+                foreach (var graphType in compatibleGraphTypes)
+                {
+                    specificNodes.Add(new NodeSpecificToGraph
+                    {
+                        nodeType = nodeType,
+                        isCompatibleWithGraph = compatibleMethods,
+                        compatibleWithGraphType = graphType
+                    });
+                }
+                return true;
+            }
+            return false;
+        }
 
-				AddNodeScriptAsset(nodeType);
-			}
+        static void BuildScriptCache()
+        {
+            foreach (var nodeType in TypeCache.GetTypesDerivedFrom<BaseNode>())
+            {
+                if (!IsNodeAccessibleFromMenu(nodeType))
+                    continue;
 
-			foreach (var nodeViewType in TypeCache.GetTypesDerivedFrom<BaseNodeView>())
-			{
-				if (!nodeViewType.IsAbstract)
-					AddNodeViewScriptAsset(nodeViewType);
-			}
-		}
+                AddNodeScriptAsset(nodeType);
+            }
 
-		static FieldInfo SetGraph = typeof(BaseNode).GetField("graph", BindingFlags.NonPublic | BindingFlags.Instance);
-		static void ProvideNodePortCreationDescription(Type nodeType, NodeDescriptions targetDescription, BaseGraph graph = null)
-		{
-			var node = Activator.CreateInstance(nodeType) as BaseNode;
-			try {
-				SetGraph.SetValue(node, graph);
-				node.InitializePorts();
-				node.UpdateAllPorts();
-			} catch (Exception) { }
+            foreach (var nodeViewType in TypeCache.GetTypesDerivedFrom<BaseNodeView>())
+            {
+                if (!nodeViewType.IsAbstract)
+                    AddNodeViewScriptAsset(nodeViewType);
+            }
+        }
 
-			foreach (var p in node.inputPorts)
-				AddPort(p, true);
-			foreach (var p in node.outputPorts)
-				AddPort(p, false);
+        static FieldInfo SetGraph = typeof(BaseNode).GetField("graph", BindingFlags.NonPublic | BindingFlags.Instance);
+        static void ProvideNodePortCreationDescription(Type nodeType, NodeDescriptions targetDescription, BaseGraph graph = null)
+        {
+            var node = Activator.CreateInstance(nodeType) as BaseNode;
+            try
+            {
+                SetGraph.SetValue(node, graph);
+                node.InitializePorts();
+                node.UpdateAllPorts();
+            }
+            catch (Exception) { }
 
-			void AddPort(NodePort p, bool input)
-			{
-				targetDescription.nodeCreatePortDescription.Add(new PortDescription{
-					nodeType = nodeType,
-					portType = p.portData.displayType ?? p.fieldInfo.FieldType,
-					isInput = input,
-					portFieldName = p.fieldName,
-					portDisplayName = p.portData.displayName ?? p.fieldName,
-					portIdentifier = p.portData.identifier,
-				});
-			}
-		}
+            foreach (var p in node.inputPorts)
+                AddPort(p, true);
+            foreach (var p in node.outputPorts)
+                AddPort(p, false);
 
-		static void AddNodeScriptAsset(Type type)
-		{
-			var nodeScriptAsset = FindScriptFromClassName(type.Name);
+            void AddPort(NodePort p, bool input)
+            {
+                targetDescription.nodeCreatePortDescription.Add(new PortDescription
+                {
+                    nodeType = nodeType,
+                    portType = p.portData.displayType ?? p.fieldInfo.FieldType,
+                    isInput = input,
+                    portFieldName = p.fieldName,
+                    portDisplayName = p.portData.displayName ?? p.fieldName,
+                    portIdentifier = p.portData.identifier,
+                });
+            }
+        }
 
-			// Try find the class name with Node name at the end
-			if (nodeScriptAsset == null)
-				nodeScriptAsset = FindScriptFromClassName(type.Name + "Node");
-			if (nodeScriptAsset != null)
-				nodeScripts[type] = nodeScriptAsset;
-		}
+        static void AddNodeScriptAsset(Type type)
+        {
+            var nodeScriptAsset = FindScriptFromClassName(type.Name);
 
-		static void	AddNodeViewScriptAsset(Type type)
-		{
-			var attrs = type.GetCustomAttributes(typeof(NodeCustomEditor), false) as NodeCustomEditor[];
+            // Try find the class name with Node name at the end
+            if (nodeScriptAsset == null)
+                nodeScriptAsset = FindScriptFromClassName(type.Name + "Node");
+            if (nodeScriptAsset != null)
+                nodeScripts[type] = nodeScriptAsset;
+        }
 
-			if (attrs != null && attrs.Length > 0)
-			{
-				Type nodeType = attrs.First().nodeType;
-				nodeViewPerType[nodeType] = type;
+        static void AddNodeViewScriptAsset(Type type)
+        {
+            var attrs = type.GetCustomAttributes(typeof(NodeCustomEditor), false) as NodeCustomEditor[];
 
-				var nodeViewScriptAsset = FindScriptFromClassName(type.Name);
-				if (nodeViewScriptAsset == null)
-					nodeViewScriptAsset = FindScriptFromClassName(type.Name + "View");
-				if (nodeViewScriptAsset == null)
-					nodeViewScriptAsset = FindScriptFromClassName(type.Name + "NodeView");
+            if (attrs != null && attrs.Length > 0)
+            {
+                Type nodeType = attrs.First().nodeType;
+                nodeViewPerType[nodeType] = type;
 
-				if (nodeViewScriptAsset != null)
-					nodeViewScripts[type] = nodeViewScriptAsset;
-			}
-		}
+                var nodeViewScriptAsset = FindScriptFromClassName(type.Name);
+                if (nodeViewScriptAsset == null)
+                    nodeViewScriptAsset = FindScriptFromClassName(type.Name + "View");
+                if (nodeViewScriptAsset == null)
+                    nodeViewScriptAsset = FindScriptFromClassName(type.Name + "NodeView");
 
-		static MonoScript FindScriptFromClassName(string className)
-		{
-			var scriptGUIDs = AssetDatabase.FindAssets($"t:script {className}");
+                if (nodeViewScriptAsset != null)
+                    nodeViewScripts[type] = nodeViewScriptAsset;
+            }
+        }
 
-			if (scriptGUIDs.Length == 0)
-				return null;
+        static MonoScript FindScriptFromClassName(string className)
+        {
+            var scriptGUIDs = AssetDatabase.FindAssets($"t:script {className}");
 
-			foreach (var scriptGUID in scriptGUIDs)
-			{
-				var assetPath = AssetDatabase.GUIDToAssetPath(scriptGUID);
-				var script = AssetDatabase.LoadAssetAtPath<MonoScript>(assetPath);
+            if (scriptGUIDs.Length == 0)
+                return null;
 
-				if (script != null && String.Equals(className, Path.GetFileNameWithoutExtension(assetPath), StringComparison.OrdinalIgnoreCase))
-					return script;
-			}
+            foreach (var scriptGUID in scriptGUIDs)
+            {
+                var assetPath = AssetDatabase.GUIDToAssetPath(scriptGUID);
+                var script = AssetDatabase.LoadAssetAtPath<MonoScript>(assetPath);
 
-			return null;
-		}
+                if (script != null && String.Equals(className, Path.GetFileNameWithoutExtension(assetPath), StringComparison.OrdinalIgnoreCase))
+                    return script;
+            }
 
-		public static Type GetNodeViewTypeFromType(Type nodeType)
-		{
-			Type view;
+            return null;
+        }
+
+        public static Type GetNodeViewTypeFromType(Type nodeType)
+        {
+            Type view;
 
             if (nodeViewPerType.TryGetValue(nodeType, out view))
                 return view;
@@ -275,83 +279,127 @@ namespace GraphProcessor
             return view;
         }
 
-        public static IEnumerable<(string path, Type type)>	GetNodeMenuEntries(BaseGraph graph = null)
-		{
-			foreach (var node in genericNodes.nodePerMenuTitle)
-				yield return (node.Key, node.Value);
+        public static IEnumerable<(string path, Type type, Func<Type, Vector2, BaseNode> creationMethod)> GetNodeMenuEntries(BaseGraph graph = null)
+        {
+            Func<Type, Vector2, BaseNode> creationMethod = BaseNode.CreateFromType;
+            foreach (var node in genericNodes.nodePerMenuTitle)
+                yield return (node.Key, node.Value, creationMethod);
 
-			if (graph != null && specificNodeDescriptions.TryGetValue(graph, out var specificNodes))
-			{
-				foreach (var node in specificNodes.nodePerMenuTitle)
-					yield return (node.Key, node.Value);
-			}
-		}
+            if (graph != null && specificNodeDescriptions.TryGetValue(graph, out var specificNodes))
+            {
+                foreach (var node in specificNodes.nodePerMenuTitle)
+                    yield return (node.Key, node.Value, creationMethod);
+            }
+        }
 
-		public static MonoScript GetNodeViewScript(Type type)
-		{
-			nodeViewScripts.TryGetValue(type, out var script);
+        public static IEnumerable<(string path, Type type, Func<Type, Vector2, BaseNode> creationMethod)> GetCustomNodeMenuEntries(BaseGraph graph = null)
+        {
+            foreach (var customMenuItem in TypeCache.GetMethodsWithAttribute<CustomMenuItem>())
+            {
+                if (!IsValidCustomNodeMenuItem(customMenuItem)) continue;
 
-			return script;
-		}
+                CustomMenuItem attribute = customMenuItem.GetCustomAttributes(typeof(CustomMenuItem), true)[0] as CustomMenuItem;
 
-		public static MonoScript GetNodeScript(Type type)
-		{
-			nodeScripts.TryGetValue(type, out var script);
+                Func<Type, Vector2, BaseNode> method =
+                    Delegate.CreateDelegate(typeof(Func<Type, Vector2, BaseNode>), customMenuItem) as Func<Type, Vector2, BaseNode>;
+                yield return (attribute.menuTitle, customMenuItem.ReturnType, method);
+            }
+        }
 
-			return script;
-		}
+        public static bool IsValidCustomNodeMenuItem(MethodInfo method)
+        {
+            bool isValid = true;
+            if (!typeof(BaseNode).IsAssignableFrom(method.ReturnParameter.ParameterType))
+            {
+                Debug.LogError("CustomMenuItem: " + method.Name + " is not of return type BaseNode!");
+                isValid = false;
+            }
+            if (method.GetParameters().Length != 2)
+            {
+                Debug.LogError("CustomMenuItem: " + method.Name + " params should only be Type and Vector2!");
+                isValid = false;
+            }
+            else
+            {
+                if (method.GetParameters()[0].ParameterType != typeof(Type))
+                {
+                    Debug.LogError("CustomMenuItem: " + method.Name + " first param should be of type Type!");
+                    isValid = false;
+                }
+                if (method.GetParameters()[1].ParameterType != typeof(Vector2))
+                {
+                    Debug.LogError("CustomMenuItem: " + method.Name + " second param should be of type Vector2!");
+                    isValid = false;
+                }
+            }
+            return isValid;
+        }
 
-		public static IEnumerable<Type> GetSlotTypes(BaseGraph graph = null) 
-		{
-			foreach (var type in genericNodes.slotTypes)
-				yield return type;
+        public static MonoScript GetNodeViewScript(Type type)
+        {
+            nodeViewScripts.TryGetValue(type, out var script);
 
-			if (graph != null && specificNodeDescriptions.TryGetValue(graph, out var specificNodes))
-			{
-				foreach (var type in specificNodes.slotTypes)
-					yield return type;
-			}
-		}
+            return script;
+        }
 
-		public static IEnumerable<PortDescription> GetEdgeCreationNodeMenuEntry(PortView portView, BaseGraph graph = null)
-		{
-			foreach (var description in genericNodes.nodeCreatePortDescription)
-			{
-				if (!IsPortCompatible(description))
-					continue;
+        public static MonoScript GetNodeScript(Type type)
+        {
+            nodeScripts.TryGetValue(type, out var script);
 
-				yield return description;
-			}
+            return script;
+        }
 
-			if (graph != null && specificNodeDescriptions.TryGetValue(graph, out var specificNodes))
-			{
-				foreach (var description in specificNodes.nodeCreatePortDescription)
-				{
-					if (!IsPortCompatible(description))
-						continue;
-					yield return description;
-				}
-			}
+        public static IEnumerable<Type> GetSlotTypes(BaseGraph graph = null)
+        {
+            foreach (var type in genericNodes.slotTypes)
+                yield return type;
 
-			bool IsPortCompatible(PortDescription description)
-			{
-				if ((portView.direction == Direction.Input && description.isInput) || (portView.direction == Direction.Output && !description.isInput))
-					return false;
+            if (graph != null && specificNodeDescriptions.TryGetValue(graph, out var specificNodes))
+            {
+                foreach (var type in specificNodes.slotTypes)
+                    yield return type;
+            }
+        }
 
-				if (portView.direction == Direction.Input)
-				{
-					if (!BaseGraph.TypesAreConnectable(description.portType, portView.portType))
-						return false;
-				}
-				else
-				{
-					if (!BaseGraph.TypesAreConnectable( portView.portType, description.portType))
-						return false;
-				}
-	
-					
-				return true;
-			}
-		}
-	}
+        public static IEnumerable<PortDescription> GetEdgeCreationNodeMenuEntry(PortView portView, BaseGraph graph = null)
+        {
+            foreach (var description in genericNodes.nodeCreatePortDescription)
+            {
+                if (!IsPortCompatible(description))
+                    continue;
+
+                yield return description;
+            }
+
+            if (graph != null && specificNodeDescriptions.TryGetValue(graph, out var specificNodes))
+            {
+                foreach (var description in specificNodes.nodeCreatePortDescription)
+                {
+                    if (!IsPortCompatible(description))
+                        continue;
+                    yield return description;
+                }
+            }
+
+            bool IsPortCompatible(PortDescription description)
+            {
+                if ((portView.direction == Direction.Input && description.isInput) || (portView.direction == Direction.Output && !description.isInput))
+                    return false;
+
+                if (portView.direction == Direction.Input)
+                {
+                    if (!BaseGraph.TypesAreConnectable(description.portType, portView.portType))
+                        return false;
+                }
+                else
+                {
+                    if (!BaseGraph.TypesAreConnectable(portView.portType, description.portType))
+                        return false;
+                }
+
+
+                return true;
+            }
+        }
+    }
 }

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
@@ -1435,13 +1435,20 @@ namespace GraphProcessor
 
         protected virtual void InitializeView() { }
 
-        public virtual IEnumerable<(string path, Type type)> FilterCreateNodeMenuEntries()
+        public virtual IEnumerable<(string path, Type type, Func<Type, Vector2, BaseNode> creationMethod)> FilterCreateNodeMenuEntries()
         {
             // By default we don't filter anything
             foreach (var nodeMenuItem in NodeProvider.GetNodeMenuEntries(graph))
                 yield return nodeMenuItem;
 
             // TODO: add exposed properties to this list
+        }
+
+        public virtual IEnumerable<(string path, Type type, Func<Type, Vector2, BaseNode> creationMethod)> FilterCreateCustomNodeMenuEntries()
+        {
+            // By default we don't filter anything
+            foreach (var customMenuItem in NodeProvider.GetCustomNodeMenuEntries(graph))
+                yield return customMenuItem;
         }
 
         public RelayNodeView AddRelayNode(PortView inputPort, PortView outputPort, Vector2 position)

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/CreateNodeMenuWindow.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/CreateNodeMenuWindow.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,12 +14,12 @@ namespace GraphProcessor
     // TODO: replace this by the new UnityEditor.Searcher package
     class CreateNodeMenuWindow : ScriptableObject, ISearchWindowProvider
     {
-        BaseGraphView   graphView;
-        EditorWindow    window;
-        Texture2D       icon;
-        EdgeView        edgeFilter;
-        PortView        inputPortView;
-        PortView        outputPortView;
+        BaseGraphView graphView;
+        EditorWindow window;
+        Texture2D icon;
+        EdgeView edgeFilter;
+        PortView inputPortView;
+        PortView outputPortView;
 
         public void Initialize(BaseGraphView graphView, EditorWindow window, EdgeView edgeFilter = null)
         {
@@ -62,89 +63,25 @@ namespace GraphProcessor
         void CreateStandardNodeMenu(List<SearchTreeEntry> tree)
         {
             // Sort menu by alphabetical order and submenus
-            var nodeEntries = graphView.FilterCreateNodeMenuEntries().OrderBy(k => k.path);
-            var titlePaths = new HashSet< string >();
-            
-			foreach (var nodeMenuItem in nodeEntries)
-			{
+            var nodeEntries = graphView.FilterCreateNodeMenuEntries()
+                .Concat(graphView.FilterCreateCustomNodeMenuEntries())
+                .OrderBy(k => k.path);
+
+            var titlePaths = new HashSet<string>();
+
+            foreach (var nodeMenuItem in nodeEntries)
+            {
                 var nodePath = nodeMenuItem.path;
                 var nodeName = nodePath;
-                var level    = 0;
-                var parts    = nodePath.Split('/');
-
-                if(parts.Length > 1)
-                {
-                    level++;
-                    nodeName = parts[parts.Length - 1];
-                    var fullTitleAsPath = "";
-                    
-                    for(var i = 0; i < parts.Length - 1; i++)
-                    {
-                        var title = parts[i];
-                        fullTitleAsPath += title;
-                        level = i + 1;
-                        
-                        // Add section title if the node is in subcategory
-                        if (!titlePaths.Contains(fullTitleAsPath))
-                        {
-                            tree.Add(new SearchTreeGroupEntry(new GUIContent(title)){
-                                level = level
-                            });
-                            titlePaths.Add(fullTitleAsPath);
-                        }
-                    }
-                }
-                
-                tree.Add(new SearchTreeEntry(new GUIContent(nodeName, icon))
-                {
-                    level    = level + 1,
-                    userData = nodeMenuItem.type
-                });
-			}
-        }
-
-        void CreateEdgeNodeMenu(List<SearchTreeEntry> tree)
-        {
-            var entries = NodeProvider.GetEdgeCreationNodeMenuEntry((edgeFilter.input ?? edgeFilter.output) as PortView, graphView.graph);
-
-            var titlePaths = new HashSet< string >();
-
-            var nodePaths = NodeProvider.GetNodeMenuEntries(graphView.graph);
-
-            tree.Add(new SearchTreeEntry(new GUIContent($"Relay", icon))
-            {
-                level = 1,
-                userData = new NodeProvider.PortDescription{
-			        nodeType = typeof(RelayNode),
-			        portType = typeof(System.Object),
-			        isInput = inputPortView != null,
-			        portFieldName = inputPortView != null ? nameof(RelayNode.output) : nameof(RelayNode.input),
-			        portIdentifier = "0",
-			        portDisplayName = inputPortView != null ? "Out" : "In",
-                }
-            });
-
-            var sortedMenuItems = entries.Select(port => (port, nodePaths.FirstOrDefault(kp => kp.type == port.nodeType).path)).OrderBy(e => e.path);
-
-            // Sort menu by alphabetical order and submenus
-			foreach (var nodeMenuItem in sortedMenuItems)
-			{
-                var nodePath = nodePaths.FirstOrDefault(kp => kp.type == nodeMenuItem.port.nodeType).path;
-
-                // Ignore the node if it's not in the create menu
-                if (String.IsNullOrEmpty(nodePath))
-                    continue;
-
-                var nodeName = nodePath;
-                var level    = 0;
-                var parts    = nodePath.Split('/');
+                var level = 0;
+                var parts = nodePath.Split('/');
 
                 if (parts.Length > 1)
                 {
                     level++;
                     nodeName = parts[parts.Length - 1];
                     var fullTitleAsPath = "";
-                    
+
                     for (var i = 0; i < parts.Length - 1; i++)
                     {
                         var title = parts[i];
@@ -154,7 +91,8 @@ namespace GraphProcessor
                         // Add section title if the node is in subcategory
                         if (!titlePaths.Contains(fullTitleAsPath))
                         {
-                            tree.Add(new SearchTreeGroupEntry(new GUIContent(title)){
+                            tree.Add(new SearchTreeGroupEntry(new GUIContent(title))
+                            {
                                 level = level
                             });
                             titlePaths.Add(fullTitleAsPath);
@@ -162,12 +100,85 @@ namespace GraphProcessor
                     }
                 }
 
-                tree.Add(new SearchTreeEntry(new GUIContent($"{nodeName}:  {nodeMenuItem.port.portDisplayName}", icon))
+                tree.Add(new SearchTreeEntry(new GUIContent(nodeName, icon))
                 {
-                    level    = level + 1,
-                    userData = nodeMenuItem.port
+                    level = level + 1,
+                    userData = new Tuple<Type, Func<Type, Vector2, BaseNode>>(nodeMenuItem.type, nodeMenuItem.creationMethod)
                 });
-			}
+            }
+        }
+
+        void CreateEdgeNodeMenu(List<SearchTreeEntry> tree)
+        {
+            var entries = NodeProvider.GetEdgeCreationNodeMenuEntry((edgeFilter.input ?? edgeFilter.output) as PortView, graphView.graph);
+
+            var titlePaths = new HashSet<string>();
+
+            var nodePaths = NodeProvider.GetNodeMenuEntries(graphView.graph).Concat(NodeProvider.GetCustomNodeMenuEntries(graphView.graph));
+            // var customMenuEntries = 
+
+            tree.Add(new SearchTreeEntry(new GUIContent($"Relay", icon))
+            {
+                level = 1,
+                userData = new NodeProvider.PortDescription
+                {
+                    nodeType = typeof(RelayNode),
+                    portType = typeof(System.Object),
+                    isInput = inputPortView != null,
+                    portFieldName = inputPortView != null ? nameof(RelayNode.output) : nameof(RelayNode.input),
+                    portIdentifier = "0",
+                    portDisplayName = inputPortView != null ? "Out" : "In",
+                }
+            });
+
+            var sortedMenuItems = entries.Select(port => (port, nodePaths.FirstOrDefault(kp => kp.type == port.nodeType).path)).OrderBy(e => e.path);
+
+            // Sort menu by alphabetical order and submenus
+            foreach (var nodeMenuItem in sortedMenuItems)
+            {
+                foreach (var node in nodePaths.Where(kp => kp.type == nodeMenuItem.port.nodeType))
+                {
+                    var nodePath = node.path;
+
+                    // Ignore the node if it's not in the create menu
+                    if (String.IsNullOrEmpty(nodePath))
+                        continue;
+
+                    var nodeName = nodePath;
+                    var level = 0;
+                    var parts = nodePath.Split('/');
+
+                    if (parts.Length > 1)
+                    {
+                        level++;
+                        nodeName = parts[parts.Length - 1];
+                        var fullTitleAsPath = "";
+
+                        for (var i = 0; i < parts.Length - 1; i++)
+                        {
+                            var title = parts[i];
+                            fullTitleAsPath += title;
+                            level = i + 1;
+
+                            // Add section title if the node is in subcategory
+                            if (!titlePaths.Contains(fullTitleAsPath))
+                            {
+                                tree.Add(new SearchTreeGroupEntry(new GUIContent(title))
+                                {
+                                    level = level
+                                });
+                                titlePaths.Add(fullTitleAsPath);
+                            }
+                        }
+                    }
+
+                    tree.Add(new SearchTreeEntry(new GUIContent($"{nodeName}:  {nodeMenuItem.port.portDisplayName}", icon))
+                    {
+                        level = level + 1,
+                        userData = new Tuple<NodeProvider.PortDescription, Func<Type, Vector2, BaseNode>>(nodeMenuItem.port, node.creationMethod)
+                    });
+                }
+            }
         }
 
         // Node creation when validate a choice
@@ -178,14 +189,25 @@ namespace GraphProcessor
             var windowMousePosition = windowRoot.ChangeCoordinatesTo(windowRoot.parent, context.screenMousePosition - window.position.position);
             var graphMousePosition = graphView.contentViewContainer.WorldToLocal(windowMousePosition);
 
-            var nodeType = searchTreeEntry.userData is Type ? (Type)searchTreeEntry.userData : ((NodeProvider.PortDescription)searchTreeEntry.userData).nodeType;
-            
-            graphView.RegisterCompleteObjectUndo("Added " + nodeType);
-            var view = graphView.AddNode(BaseNode.CreateFromType(nodeType, graphMousePosition));
-
-            if (searchTreeEntry.userData is NodeProvider.PortDescription desc)
+            if (searchTreeEntry.userData is Tuple<Type, Func<Type, Vector2, BaseNode>>)
             {
-                var targetPort = view.GetPortViewFromFieldName(desc.portFieldName, desc.portIdentifier);
+                Tuple<Type, Func<Type, Vector2, BaseNode>> userData = searchTreeEntry.userData as Tuple<Type, Func<Type, Vector2, BaseNode>>;
+                var nodeType = userData.Item1;
+                var method = userData.Item2;
+
+                graphView.RegisterCompleteObjectUndo("Added " + nodeType);
+                graphView.AddNode(method.Invoke(nodeType, graphMousePosition));
+            }
+            else
+            {
+                Tuple<NodeProvider.PortDescription, Func<Type, Vector2, BaseNode>> userData = searchTreeEntry.userData as Tuple<NodeProvider.PortDescription, Func<Type, Vector2, BaseNode>>;
+                var nodeType = userData.Item1.nodeType;
+                var method = userData.Item2;
+
+                graphView.RegisterCompleteObjectUndo("Added " + nodeType);
+                BaseNodeView view = graphView.AddNode(method.Invoke(nodeType, graphMousePosition));
+
+                var targetPort = view.GetPortViewFromFieldName(userData.Item1.portFieldName, userData.Item1.portIdentifier);
                 if (inputPortView == null)
                     graphView.Connect(targetPort, outputPortView);
                 else

--- a/Assets/com.alelievr.NodeGraphProcessor/Runtime/Graph/Attributes.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Runtime/Graph/Attributes.cs
@@ -247,4 +247,22 @@ namespace GraphProcessor
 
     [AttributeUsage(AttributeTargets.Method)]
     public class IsCompatibleWithGraph : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class CustomMenuItem : Attribute
+    {
+        public string menuTitle;
+        public Type onlyCompatibleWithGraph;
+
+        /// <summary>
+        /// Register the node creation method in the NodeProvider class. The node creation method will also be available in the node creation window.
+        /// </summary>
+        /// <param name="menuTitle">Path in the menu, use / as folder separators</param>
+        /// <param name="onlyCompatibleWithGraph">Currently does nothing.</param>
+        public CustomMenuItem(string menuTitle = null, Type onlyCompatibleWithGraph = null)
+        {
+            this.menuTitle = menuTitle;
+            this.onlyCompatibleWithGraph = onlyCompatibleWithGraph;
+        }
+    }
 }


### PR DESCRIPTION
Added attribute for setting methods as custom node creation menu items. Same as the NodeMenuItem.

Switched return type in BaseGraphView & NodeProvider to string, Type, Func<Type, Vector2, BaseNode> to match my new methods for returning the new attribute methods. This way we enforce all attributes to the correct Node creation format and can use the BaseNode.CreateNode method.

I've also added an example.